### PR TITLE
Gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/Gemfile.lock
+/.bundle
+/log/*
+/tmp/*
+spec/examples.txt

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Dependencies declared in schema_version_cache.gemspec
+gemspec

--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# SchemaVersionCache
+
+Make Avro schema version queries fast and easy.
+
+## Installation
+
+Add to the application's Gemfile:
+```ruby
+gem "schema_version_cache", source: "https://gem.odeko.com/"
+```
+
+## Usage
+
+Initialize a schema registry client and a cache:
+```ruby
+# config/initializers/kafka.rb
+
+require "avro_turf/messaging"
+
+registry = AvroTurf::ConfluentSchemaRegistry.new(
+  ENV["CONFLUENT_SCHEMA_REGISTRY_URL"],
+  user: ENV["CONFLUENT_SCHEMA_REGISTRY_USER"],
+  password: ENV["CONFLUENT_SCHEMA_REGISTRY_PASSWORD"]
+)
+AvroSchemaVersionCache = SchemaVersionCache.new(registry)
+```
+
+Optionally, preload the cache on startup:
+```ruby
+# config/racecar.rb
+
+Racecar.configure do |config|
+  # ...
+  AvroSchemaVersionCache.preload(
+    [
+      "com.odeko.foo_service.Foo_value",
+      "com.odeko.bar_service.Bar_value"
+    ]
+  )
+end
+```
+
+Run schema queries as needed:
+```ruby
+subject = "com.odeko.foo_service.Foo_value"
+schema_id = AvroSchemaVersionCache.get_current_id(subject:)
+version_number = AvroSchemaVersionCache.get_version_number(subject:, schema_id:)
+```
+
+## Development
+
+Prerequisites: Ruby and bundler.
+
+Install project dependencies:
+```console
+$ bin/setup
+```
+
+Run the test-suite:
+```console
+$ bin/ci-test
+```
+
+Run the linter:
+```console
+$ bin/lint
+```

--- a/bin/ci-test
+++ b/bin/ci-test
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+bundle exec rspec

--- a/bin/lint
+++ b/bin/lint
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+bundle exec standardrb --parallel

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install

--- a/lib/schema_version_cache.rb
+++ b/lib/schema_version_cache.rb
@@ -1,0 +1,61 @@
+class SchemaVersionCache
+  SchemaNotFound = Class.new(StandardError)
+  SubjectLookupError = Class.new(StandardError)
+
+  # Registry is expected to provide the following methods:
+  # - subject_versions: Given a subject, return an array of version numbers.
+  # - subject_version: Given a subject and version number, return a hash of
+  #   schema data including schema ID under key "id".
+  #
+  # In practice, we use AvroTurf::ConfluentSchemaRegistry, but for flexibility
+  # and ease of testing, any object providing the necessary methods will work.
+  def initialize(registry)
+    @registry = registry
+    @cache = {} # Hash[Subject, Hash[SchemaId, VersionNumber]]
+  end
+
+  def preload(subjects)
+    subjects.each { |subject| add_subject_versions_to_cache(subject) }
+  end
+
+  def get_version_number(subject:, schema_id:)
+    if @cache.key?(subject) && @cache.fetch(subject).key?(schema_id)
+      return @cache.fetch(subject).fetch(schema_id)
+    end
+
+    add_subject_versions_to_cache(subject)
+    @cache.dig(subject, schema_id) || schema_not_found(subject:, schema_id:)
+  end
+
+  def get_current_id(subject:)
+    if @cache.key?(subject) && @cache.fetch(subject).keys.any?
+      return @cache.fetch(subject).keys.max
+    end
+
+    add_subject_versions_to_cache(subject)
+    @cache.fetch(subject, {}).keys.max || schema_not_found(subject:)
+  end
+
+  private
+
+  def add_subject_versions_to_cache(subject)
+    version_numbers = @registry.subject_versions(subject)
+    @cache[subject] = version_numbers.reduce({}) do |hash, version_number|
+      schema_data = @registry.subject_version(subject, version_number)
+      schema_id = schema_data.fetch("id")
+      hash.merge!(schema_id => version_number)
+    end
+  rescue => e
+    raise SubjectLookupError, <<~ERR.chomp
+      Could not lookup versions for subject "#{subject}": #{e}
+    ERR
+  end
+
+  def schema_not_found(**attributes)
+    raise SchemaNotFound, <<~ERR.chomp
+      Could not find schema with attributes: #{
+        attributes.map { |key, val| "#{key}=#{val}" }.join(", ")
+      }
+    ERR
+  end
+end

--- a/schema_version_cache.gemspec
+++ b/schema_version_cache.gemspec
@@ -1,0 +1,16 @@
+Gem::Specification.new do |s|
+  s.name = "schema_version_cache"
+  s.version = "1.0.0"
+  s.summary = "Schema version cache"
+  s.description = "Schema version cache, e.g. for Avro schemas"
+  s.authors = ["Odeko"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject do |f|
+      (f == __FILE__) || f.match(%r{\A(?:(?:bin|spec|ci)/|\.(?:git))})
+    end
+  end
+  s.license = "Nonstandard"
+  s.add_development_dependency("rake", "~> 13.0")
+  s.add_development_dependency("rspec", "~> 3.0")
+  s.add_development_dependency("standard", "~> 1.3")
+end

--- a/spec/schema_version_cache_spec.rb
+++ b/spec/schema_version_cache_spec.rb
@@ -1,0 +1,120 @@
+require "schema_version_cache"
+
+class TestRegistry
+  def initialize(data)
+    @data = data
+  end
+
+  def subject_versions(subject)
+    @data.fetch(subject).keys
+  end
+
+  def subject_version(subject, version)
+    @data.fetch(subject).fetch(version)
+  end
+end
+
+describe SchemaVersionCache do
+  let(:registry_data) do
+    {
+      "foo" => {
+        1 => {"id" => 1000},
+        2 => {"id" => 1001},
+        3 => {"id" => 1002}
+      },
+      "bar" => {
+        1 => {"id" => 2000},
+        2 => {"id" => 2001}
+      },
+      "baz" => {
+        1 => {"id" => 3000},
+        2 => {"id" => 3001}
+      }
+    }
+  end
+  let(:instance) do
+    described_class.new(TestRegistry.new(registry_data))
+  end
+
+  describe "#get_version_number" do
+    let(:data_lists) do
+      registry_data.flat_map do |subject, data|
+        data.map do |version, val|
+          [subject, val["id"], version]
+        end
+      end
+    end
+
+    it "returns version number" do
+      data_lists.each do |subject, schema_id, version|
+        expect(instance.get_version_number(subject:, schema_id:)).to eq(version)
+      end
+    end
+
+    it "uses cache when possible" do
+      data_lists.each do |subject, schema_id, version|
+        instance.get_version_number(subject:, schema_id:)
+      end
+      registry_data.keys.each { |subject| registry_data.delete(subject) }
+
+      data_lists.each do |subject, schema_id, version|
+        expect(instance.get_version_number(subject:, schema_id:)).to eq(version)
+      end
+    end
+
+    it "raises an error if schema cannot be found" do
+      expect { instance.get_version_number(subject: "foo", schema_id: 2000) }
+        .to raise_error(described_class::SchemaNotFound)
+    end
+  end
+
+  describe "#get_current_id" do
+    let(:data_lists) do
+      registry_data.map do |subject, data|
+        max_id = data.map { |_version, val| val["id"] }.max
+        [subject, max_id]
+      end
+    end
+
+    it "returns highest ID for subject" do
+      data_lists.each do |subject, max_id|
+        expect(instance.get_current_id(subject:)).to eq(max_id)
+      end
+    end
+
+    it "uses cache when possible" do
+      data_lists.each do |subject, max_id|
+        instance.get_current_id(subject:)
+      end
+      registry_data.keys.each { |subject| registry_data.delete(subject) }
+
+      data_lists.each do |subject, max_id|
+        expect(instance.get_current_id(subject:)).to eq(max_id)
+      end
+    end
+
+    it "raises an error if schema cannot be found" do
+      expect { instance.get_current_id(subject: "quack") }
+        .to raise_error(described_class::SubjectLookupError)
+    end
+  end
+
+  describe "#preload" do
+    let(:data_lists) do
+      registry_data.map do |subject, data|
+        max_id = data.map { |_version, val| val["id"] }.max
+        [subject, max_id]
+      end
+    end
+
+    it "adds specified subjects to cache" do
+      instance.preload(["foo", "bar"])
+      registry_data.keys.each { |subject| registry_data.delete(subject) }
+
+      expect(instance.get_current_id(subject: "foo")).to eq(1002)
+      expect(instance.get_current_id(subject: "bar")).to eq(2001)
+      expect { instance.get_current_id(subject: "baz") }
+        .to raise_error(described_class::SubjectLookupError)
+    end
+  end
+end


### PR DESCRIPTION
Package schema version cache logic as a gem.

### Details
This gem encompasses logic we've duplicated [across several applications](https://github.com/search?q=org%3AOdekoTeam+SchemaVersionCache+path%3Aapp%2Flib%2Fschema_version_cache.rb&type=code). Packaging it as a gem will be beneficial as we migrate several applications to an asynchronous message-processing strategy (e.g. [sc-50877](https://app.shortcut.com/odeko/story/50877/so-api-customercommandsreceiver-suffers-from-synchronous-failures)).

### Planned followup PRs

- set up the `ci/` directory and corresponding concourse pipelines
- add static type-checking