### PR TITLE
Add ci/tasks/version.yml

### DIFF
--- a/ci/tasks/version.yml
+++ b/ci/tasks/version.yml
@@ -1,0 +1,23 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: alpine/git
+inputs:
+- name: repo
+outputs:
+- name: repo-version
+run:
+  path: /bin/sh
+  args:
+  - -c
+  - |
+    # exit on error
+    set -e
+
+    echo "Getting version from schema_version_cache.gemspec"
+    VERSION=$(awk '/^ +\w+\.version *= *\S+$/ { print $NF }' schema_version_cache.gemspec | tr -d "\"'")
+
+    echo "Found version ${VERSION}"
+    mkdir -p repo-version
+    echo ${VERSION} > repo-version/VERSION


### PR DESCRIPTION
Add a ci task capable of extracting the version number from our gemspec. This will unblock us from setting up ci pipelines.

It boils down to:
```sh
# Find the gemspec line that assigns a version.
# Print the last word on that line.
# Delete surrounding quotes.
awk '/^ +\w+\.version *= *\S+$/ { print $NF }' schema_version_cache.gemspec \
    | tr -d "\"'"
```
output:
```
1.0.0
```