### PR TITLE
Fix CI: conditional release params

### DIFF
--- a/ci/pipelines/main.yml
+++ b/ci/pipelines/main.yml
@@ -107,7 +107,7 @@ jobs:
   - task: version-check
     file: concourse/tasks/rails/version-check/default.yml
     params:
-      GATED_JOB: schema-version-cache/gem-publish
+      GATED_JOB: schema-version-cache-main/gem-publish
     attempts: 3
 - name: gem-publish
   serial: true


### PR DESCRIPTION
Fix an incorrect param in the main CI pipeline that prevented conditional release logic from working.

The error this fixes can be seen in this [build](https://concourse.odeko.com/teams/main/pipelines/schema-version-cache-main/jobs/version-check/builds/3#L6662c896:23).
___
- [x] `fly -t odeko set-pipeline -p schema-version-cache-main -c ci/pipelines/main.yml`