### PR TITLE
Don't use `git ls-files` in gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    schema_version_cache (1.2.0)
+    schema_version_cache (1.2.1)
       avro (~> 1.11)
 
 GEM

--- a/schema_version_cache.gemspec
+++ b/schema_version_cache.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "schema_version_cache"
-  s.version = "1.2.0"
+  s.version = "1.2.1"
   s.summary = "Schema version cache"
   s.description = "Schema version cache, e.g. for Avro schemas"
   s.authors = ["Odeko"]


### PR DESCRIPTION
Don't use `git ls-files` while constructing the gemspec's file list.

#### Context
Using `git ls-files` for this purpose became widespread, but is now [discouraged](https://github.com/rubygems/rubygems/issues/4047), because building the gem from source will fail on a host that lacks git, and using the gem will in some circumstances emit an annoying error/warning:

    fatal: Not a git repository (or any of the parent directories): .git