### PR TITLE
use dedicated docker hub passthru proxy

### DIFF
--- a/ci/pipelines/main.yml
+++ b/ci/pipelines/main.yml
@@ -4,6 +4,8 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+    registry_mirror:
+      host: docker-mirror.odeko.com
 
 resources:
 - name: repo-release

--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -3,11 +3,15 @@ resource_types:
   type: registry-image
   source:
     repository: teliaoss/github-pr-resource
+    registry_mirror:
+      host: docker-mirror.odeko.com
 - name: slack-notification
   type: registry-image
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+    registry_mirror:
+      host: docker-mirror.odeko.com
 
 resources:
 - name: pull-request


### PR DESCRIPTION
Uses the new docker mirror to mitigate Docker Hub rate limiting.

Already applied.