### PR TITLE
Publish open source

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    schema_version_cache (1.3.0)
+    schema_version_cache (1.3.1)
       avro (~> 1.11)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Make Avro schema version queries fast and easy.
 
 Add to the application's Gemfile:
 ```ruby
-gem "schema_version_cache", source: "https://gem.odeko.com/"
+gem "schema_version_cache"
 ```
 
 ## Usage
@@ -35,8 +35,8 @@ Racecar.configure do |config|
   # ...
   AvroSchemaVersionCache.preload(
     [
-      "com.odeko.foo_service.Foo_value",
-      "com.odeko.bar_service.Bar_value"
+      "com.example.foo_service.Foo_value",
+      "com.example.bar_service.Bar_value"
     ]
   )
 end
@@ -44,7 +44,7 @@ end
 
 Run schema queries as needed:
 ```ruby
-subject = "com.odeko.foo_service.Foo_value"
+subject = "com.example.foo_service.Foo_value"
 schema_id = AvroSchemaVersionCache.get_current_id(subject:)
 version = AvroSchemaVersionCache.get_version_number(subject:, schema_id:)
 schema_json = AvroSchemaVersionCache.get_schema_json(subject:, version:)

--- a/ci/pipelines/main.yml
+++ b/ci/pipelines/main.yml
@@ -159,7 +159,7 @@ jobs:
   - in_parallel:
     - get: repo
       passed:
-      - gem-publish
+      - gem-publish-open-source
       trigger: true
       attempts: 3
     - get: concourse

--- a/ci/pipelines/main.yml
+++ b/ci/pipelines/main.yml
@@ -133,6 +133,26 @@ jobs:
       GEMINABOX_PRIVATE_URL: ((geminabox-url))
     attempts: 3
   on_failure: *simple_failure
+- name: gem-publish-open-source
+  serial: true
+  plan:
+  - in_parallel:
+    - get: repo
+      passed:
+      - gem-publish
+      trigger: true
+      params:
+        submodules: all
+        submodule_recursive: true
+      attempts: 3
+    - get: concourse
+      attempts: 3
+  - task: gem-publish-open-source
+    file: concourse/tasks/rails/publish-open-source/default.yml
+    params:
+      RUBYGEMS_API_KEY: ((rubygems-api-key))
+    attempts: 3
+  on_failure: *simple_failure
 - name: release
   serial: true
   plan:

--- a/schema_version_cache.gemspec
+++ b/schema_version_cache.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "schema_version_cache"
-  s.version = "1.3.0"
+  s.version = "1.3.1"
   s.summary = "Schema version cache"
   s.description = "Schema version cache, e.g. for Avro schemas"
   s.homepage = "https://github.com/OdekoTeam/schema_version_cache"


### PR DESCRIPTION
Publish this as an open-source gem, with a CI job that pushes to rubygems.org

#### Context
In #13 we added the Apache 2.0 license and updated the gemspec, in preparation for publishing this as an open-source gem. The GitHub repo visibility settings have been updated, making it publicly visible.
___
- [x] run `fly` to update pipeline:
```sh
fly -t odeko set-pipeline -p schema-version-cache-main -c ci/pipelines/main.yml
```